### PR TITLE
Protect manual mail endpoints with token check

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,27 @@
 - `server/tasks/auto_tasks.py` – Background loops with conditional notifications
 - `server/routes/mail_manage.py` – Endpoints for manual delete and auto-reply
 - `server/utils/telegram_notify.py` – Telegram helper
+
+## Manual Management API
+The manual mail management endpoints require authentication. Supply the API
+token via a `token` query parameter or an `Authorization: Bearer <token>`
+header.
+
+Example:
+
+```bash
+curl -X POST \
+  'https://<HOST>/mail/delete?token=YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{"id": 1}'
+```
+
+or
+
+```bash
+curl -X POST \
+  'https://<HOST>/mail/auto-reply' \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{"id": 1, "reply_text": "Thanks"}'
+```

--- a/server/routes/mail_manage.py
+++ b/server/routes/mail_manage.py
@@ -1,7 +1,9 @@
 # server/routes/mail_manage.py
-from fastapi import APIRouter
+from fastapi import APIRouter, Query, Request
 from pydantic import BaseModel
 import sqlite3
+
+from app import require_token
 
 router = APIRouter()
 
@@ -18,7 +20,12 @@ def get_db():
     return conn
 
 @router.post("/mail/delete")
-def mail_delete(req: DeleteRequest):
+def mail_delete(
+    req: DeleteRequest,
+    token: str | None = Query(None),
+    request: Request | None = None,
+):
+    require_token(token, request)
     conn = get_db()
     cur = conn.cursor()
     cur.execute("UPDATE mails SET deleted=1 WHERE id=?", (req.id,))
@@ -26,7 +33,12 @@ def mail_delete(req: DeleteRequest):
     return {"ok": True, "deleted_id": req.id}
 
 @router.post("/mail/auto-reply")
-def auto_reply(req: AutoReplyRequest):
+def auto_reply(
+    req: AutoReplyRequest,
+    token: str | None = Query(None),
+    request: Request | None = None,
+):
+    require_token(token, request)
     conn = get_db()
     cur = conn.cursor()
     cur.execute("UPDATE mails SET replied=1 WHERE id=?", (req.id,))


### PR DESCRIPTION
## Summary
- add token & request parameters with `require_token` check to `/mail/delete` and `/mail/auto-reply`
- document token usage for manual mail management endpoints

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c788d7269c832698e6b42757b19785