### PR TITLE
feat: add mail approval workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,15 @@ curl -X POST \
   -H 'Content-Type: application/json' \
   -d '{"id": 1, "reply_text": "Thanks"}'
 ```
+
+## Mail Approval Flow
+Certain inbound mails are not processed automatically. If a message has
+attachments, comes from a pre-defined sender list or has high importance it is
+stored with `needs_approval=1` and a Telegram message is sent with **Approve**
+and **Reject** buttons. Each button links to `/mail/approve` or `/mail/reject`
+with the mail ID.
+
+When an operator approves, the server marks the mail as approved/processed,
+saves any attachments to disk and sends a short confirmation reply. Rejecting
+removes the mail from the database. This review step helps ensure that only
+trusted messages trigger automated actions.

--- a/server/utils/telegram_notify.py
+++ b/server/utils/telegram_notify.py
@@ -16,3 +16,25 @@ def send_telegram_message(text: str, subject: str="Caia Agent 알림"):
         r.raise_for_status()
     except Exception as e:
         print("Telegram notify failed:", e)
+
+
+def send_approval_request(mail_id: int, sender: str, subject: str):
+    """Send a Telegram message asking for mail approval with action buttons."""
+    if not AUTH_TOKEN:
+        return
+    text = f"Mail #{mail_id}\nFrom: {sender}\nSubject: {subject}"
+    approve = f"{MAIL_BASE}/mail/approve?id={mail_id}&token={AUTH_TOKEN}"
+    reject = f"{MAIL_BASE}/mail/reject?id={mail_id}&token={AUTH_TOKEN}"
+    payload = {
+        "to": ["telegram"],
+        "subject": "Mail approval needed",
+        "text": text,
+        "buttons": [
+            {"text": "Approve", "url": approve},
+            {"text": "Reject", "url": reject},
+        ],
+    }
+    try:
+        requests.post(f"{MAIL_BASE}/tool/send?token={AUTH_TOKEN}", json=payload, timeout=10)
+    except Exception as e:
+        print("Telegram approval request failed:", e)


### PR DESCRIPTION
## Summary
- extend messages schema with approval flags
- send Telegram approval requests and add approve/reject endpoints
- document operator approval flow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c78ab219e08326910b6cb88f352b51