### PR TITLE
Unify mail table to messages

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,7 +89,11 @@ def init_db():
         importance REAL,
         needs_approval INTEGER DEFAULT 0,
         approved INTEGER DEFAULT 0,
-        processed INTEGER DEFAULT 0
+        processed INTEGER DEFAULT 0,
+        deleted INTEGER DEFAULT 0,
+        replied INTEGER DEFAULT 0,
+        priority TEXT DEFAULT 'normal',
+        auto_reply INTEGER DEFAULT 0
     )""")
     # ensure new columns for existing DBs
     try:
@@ -102,6 +106,22 @@ def init_db():
         pass
     try:
         conn.execute("ALTER TABLE messages ADD COLUMN processed INTEGER DEFAULT 0")
+    except Exception:
+        pass
+    try:
+        conn.execute("ALTER TABLE messages ADD COLUMN deleted INTEGER DEFAULT 0")
+    except Exception:
+        pass
+    try:
+        conn.execute("ALTER TABLE messages ADD COLUMN replied INTEGER DEFAULT 0")
+    except Exception:
+        pass
+    try:
+        conn.execute("ALTER TABLE messages ADD COLUMN priority TEXT DEFAULT 'normal'")
+    except Exception:
+        pass
+    try:
+        conn.execute("ALTER TABLE messages ADD COLUMN auto_reply INTEGER DEFAULT 0")
     except Exception:
         pass
     conn.commit()

--- a/init_messages_table.py
+++ b/init_messages_table.py
@@ -1,0 +1,10 @@
+"""Initialize or migrate the messages table schema.
+
+Run this script to create the `messages` table and ensure required
+columns (`deleted`, `replied`, `priority`, `auto_reply`, etc.) exist.
+"""
+from app import init_db
+
+if __name__ == "__main__":
+    init_db()
+    print("messages table initialized")

--- a/server/routes/mail_manage.py
+++ b/server/routes/mail_manage.py
@@ -28,7 +28,7 @@ def mail_delete(
     require_token(token, request)
     conn = get_db()
     cur = conn.cursor()
-    cur.execute("UPDATE mails SET deleted=1 WHERE id=?", (req.id,))
+    cur.execute("UPDATE messages SET deleted=1 WHERE id=?", (req.id,))
     conn.commit()
     return {"ok": True, "deleted_id": req.id}
 
@@ -41,6 +41,6 @@ def auto_reply(
     require_token(token, request)
     conn = get_db()
     cur = conn.cursor()
-    cur.execute("UPDATE mails SET replied=1 WHERE id=?", (req.id,))
+    cur.execute("UPDATE messages SET replied=1 WHERE id=?", (req.id,))
     conn.commit()
     return {"ok": True, "replied_id": req.id, "text": req.reply_text}

--- a/server/tasks/auto_tasks.py
+++ b/server/tasks/auto_tasks.py
@@ -29,11 +29,14 @@ def auto_delete(ttl_days: int = 7):
     conn = get_db()
     cur = conn.cursor()
     cutoff = datetime.utcnow() - timedelta(days=ttl_days)
-    cur.execute("SELECT id, subject FROM mails WHERE deleted=0 AND priority='low' AND created_at < ?", (cutoff.isoformat(),))
+    cur.execute(
+        "SELECT id, subject FROM messages WHERE deleted=0 AND priority='low' AND created_at < ?",
+        (cutoff.isoformat(),),
+    )
     rows = cur.fetchall()
     deleted_count = 0
     for row in rows:
-        cur.execute("UPDATE mails SET deleted=1 WHERE id=?", (row["id"],))
+        cur.execute("UPDATE messages SET deleted=1 WHERE id=?", (row["id"],))
         deleted_count += 1
     conn.commit()
     # Only notify if bulk deletion
@@ -43,12 +46,12 @@ def auto_delete(ttl_days: int = 7):
 def auto_reply():
     conn = get_db()
     cur = conn.cursor()
-    cur.execute("SELECT id, from_, subject FROM mails WHERE replied=0 AND auto_reply=1")
+    cur.execute("SELECT id, sender, subject FROM messages WHERE replied=0 AND auto_reply=1")
     rows = cur.fetchall()
     for row in rows:
         try:
             # simulate reply send
-            cur.execute("UPDATE mails SET replied=1 WHERE id=?", (row["id"],))
+            cur.execute("UPDATE messages SET replied=1 WHERE id=?", (row["id"],))
         except Exception as e:
             notify_telegram("자동답장 실패", f"메일 ID {row['id']} ({row['subject']}) 답장 실패: {e}")
     conn.commit()
@@ -56,7 +59,12 @@ def auto_reply():
 def report_high_priority():
     conn = get_db()
     cur = conn.cursor()
-    cur.execute("SELECT id, from_, subject FROM mails WHERE priority='high' AND deleted=0")
+    cur.execute(
+        "SELECT id, sender, subject FROM messages WHERE priority='high' AND deleted=0"
+    )
     rows = cur.fetchall()
     for row in rows:
-        notify_telegram("중요 메일 도착", f"{row['subject']} from {row['from_']} (ID {row['id']})")
+        notify_telegram(
+            "중요 메일 도착",
+            f"{row['subject']} from {row['sender']} (ID {row['id']})",
+        )


### PR DESCRIPTION
## Summary
- use a single `messages` table across routes and auto tasks
- extend `messages` schema with deleted/replied/priority/auto_reply flags
- add `init_messages_table.py` script to initialize or migrate the table

## Testing
- `python init_messages_table.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c78ce4500883268fd778e1bae4f805