### PR TITLE
Add critical error reporting for mail send and webhook processing

### DIFF
--- a/server/utils/error_report.py
+++ b/server/utils/error_report.py
@@ -1,0 +1,23 @@
+from typing import Callable, Optional
+
+from server.utils.telegram_notify import send_telegram_message
+
+
+def report_crit_error(message: str, fallback: Optional[Callable[[str], None]] = None) -> None:
+    """Send a CRIT level alert via Telegram.
+
+    Tries ``send_telegram_message`` first and falls back to ``fallback``
+    callable (e.g., ``app.telegram_notify``) if provided.
+    Any exceptions are swallowed to avoid cascading failures.
+    """
+    text = f"[CRIT] {message}"
+    try:
+        ok = send_telegram_message(text)
+        if not ok and fallback:
+            fallback(text)
+    except Exception:
+        if fallback:
+            try:
+                fallback(text)
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary
- add `report_crit_error` helper to send CRIT level alerts via Telegram with fallback
- wrap SendGrid send and webhook processing in try/except to notify on failures and raise HTTP 500

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c79fed83a88326b8a37e20163ee38d