### PR TITLE
Initialize chat maintenance routines and startup hook

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, EmailStr
 import requests
 
 from server.utils.telegram_notify import send_approval_request
+from server.tasks import initialize_main_chat_routines
 
 
 # --- i18n env helper (supports Korean aliases) ---
@@ -128,6 +129,12 @@ def init_db():
     conn.close()
 
 init_db()
+
+# === Routines ===
+@app.on_event("startup")
+def _initialize_routines() -> None:
+    """Start background maintenance tasks on app startup."""
+    initialize_main_chat_routines()
 
 # === Helpers ===
 def _bearer_from_header(request: Request) -> Optional[str]:

--- a/server/tasks/__init__.py
+++ b/server/tasks/__init__.py
@@ -1,0 +1,35 @@
+import threading
+import time
+from typing import Callable, List, Tuple
+
+# Store references to running routine threads
+ROUTINES: List[Tuple[str, threading.Thread]] = []
+
+
+def _run_periodic(func: Callable, interval: int) -> None:
+    """Run ``func`` every ``interval`` seconds in a loop."""
+    while True:
+        try:
+            func()
+        except Exception as e:  # pragma: no cover - best effort logging
+            print(f"[RoutineError] {func.__name__} failed: {e}")
+        time.sleep(interval)
+
+
+def initialize_main_chat_routines() -> None:
+    """Initialize background chat maintenance routines."""
+    from server.tasks import auto_tasks
+
+    # (name, callable, interval_seconds)
+    jobs: List[Tuple[str, Callable, int]] = [
+        ("auto_delete", auto_tasks.auto_delete, 60 * 60),  # hourly cleanup
+        ("auto_reply", auto_tasks.auto_reply, 60),          # every minute
+        ("report_high_priority", auto_tasks.report_high_priority, 60),  # every minute
+    ]
+
+    for name, func, interval in jobs:
+        thread = threading.Thread(
+            target=_run_periodic, args=(func, interval), daemon=True
+        )
+        thread.start()
+        ROUTINES.append((name, thread))


### PR DESCRIPTION
## Summary
- add `initialize_main_chat_routines` to schedule auto maintenance tasks
- trigger routine initialization on FastAPI startup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c79feef5a883269477a11a8a9b5d56