### PR TITLE
feat: register mail management router

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, EmailStr
 import requests
 
 from server.utils.telegram_notify import send_approval_request
+from server.routes import mail_manage
 
 
 # --- i18n env helper (supports Korean aliases) ---
@@ -43,6 +44,8 @@ app = FastAPI(
     openapi_version="3.1.0",
     servers=[{"url": "https://worker-production-4369.up.railway.app"}],
 )
+
+app.include_router(mail_manage.router, prefix="/mail")
 
 # === ENV ===
 SENDER_DEFAULT = os.getenv("SENDER_DEFAULT", "no-reply@example.com")

--- a/server/routes/mail_manage.py
+++ b/server/routes/mail_manage.py
@@ -3,8 +3,6 @@ from fastapi import APIRouter, Query, Request
 from pydantic import BaseModel
 import sqlite3
 
-from app import require_token
-
 router = APIRouter()
 
 class DeleteRequest(BaseModel):
@@ -19,12 +17,14 @@ def get_db():
     conn.row_factory = sqlite3.Row
     return conn
 
-@router.post("/mail/delete")
+@router.post("/delete")
 def mail_delete(
     req: DeleteRequest,
     token: str | None = Query(None),
     request: Request | None = None,
 ):
+    from app import require_token
+
     require_token(token, request)
     conn = get_db()
     cur = conn.cursor()
@@ -32,15 +32,23 @@ def mail_delete(
     conn.commit()
     return {"ok": True, "deleted_id": req.id}
 
-@router.post("/mail/auto-reply")
+
+@router.post("/auto-reply")
 def auto_reply(
     req: AutoReplyRequest,
     token: str | None = Query(None),
     request: Request | None = None,
 ):
+    from app import require_token
+
     require_token(token, request)
     conn = get_db()
     cur = conn.cursor()
     cur.execute("UPDATE messages SET replied=1 WHERE id=?", (req.id,))
     conn.commit()
     return {"ok": True, "replied_id": req.id, "text": req.reply_text}
+
+
+@router.get("/health")
+def health_check():
+    return {"ok": True}


### PR DESCRIPTION
## Summary
- integrate mail management router into app and apply `/mail` prefix
- expose endpoints for deletion, auto-reply, and health checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c79ff01b4c8326b2d522973124a180