### PR TITLE
chore: register mail router

### DIFF
--- a/app.py
+++ b/app.py
@@ -616,3 +616,8 @@ def webhook_telegram(request: Request):
         telegram_notify(f"🚫 거부 처리 완료 (ID {mail_id})")
         return {"ok": True, "action": "rejected", "id": mail_id}
     return {"ok": True, "skipped": "no_action"}
+
+
+from server.routes.mail_manage import router as mail_router
+
+app.include_router(mail_router)

--- a/server/routes/mail_manage.py
+++ b/server/routes/mail_manage.py
@@ -7,7 +7,7 @@ import requests
 
 from app import require_token
 
-router = APIRouter()
+router = APIRouter(prefix="/mail")
 
 class DeleteRequest(BaseModel):
     id: int
@@ -22,7 +22,7 @@ def get_db():
     return conn
 
 
-@router.get("/mail/health")
+@router.get("/health")
 def mail_health():
     detail: dict[str, str] = {}
 
@@ -76,7 +76,7 @@ def mail_health():
     )
     return {"ok": overall_ok, "detail": detail}
 
-@router.post("/mail/delete")
+@router.post("/delete")
 def mail_delete(
     req: DeleteRequest,
     token: str | None = Query(None),
@@ -89,7 +89,7 @@ def mail_delete(
     conn.commit()
     return {"ok": True, "deleted_id": req.id}
 
-@router.post("/mail/auto-reply")
+@router.post("/auto-reply")
 def auto_reply(
     req: AutoReplyRequest,
     token: str | None = Query(None),


### PR DESCRIPTION
## Summary
- add `/mail` prefix in mail routes and simplify endpoints
- register new mail router in FastAPI app

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7a44bdccc8326affa8db6097fa2f3