### PR TITLE
Fix Request parameter usage in mail routes

### DIFF
--- a/server/routes/mail_manage.py
+++ b/server/routes/mail_manage.py
@@ -82,8 +82,8 @@ def mail_health():
 @router.post("/delete")
 def mail_delete(
     req: DeleteRequest,
+    request: Request,
     token: str | None = Query(None),
-    request: Request | None = None,
 ):
     require_token(token, request)
     conn = get_db()
@@ -95,8 +95,8 @@ def mail_delete(
 @router.post("/auto-reply")
 def auto_reply(
     req: AutoReplyRequest,
+    request: Request,
     token: str | None = Query(None),
-    request: Request | None = None,
 ):
     require_token(token, request)
     conn = get_db()


### PR DESCRIPTION
## Summary
- Make `Request` a required argument for `mail_delete` and `auto_reply`
- Reorder parameters to satisfy Python's positional requirements

## Testing
- `pytest -q`
- `uvicorn app:app --host 0.0.0.0 --port 8000`


------
https://chatgpt.com/codex/tasks/task_e_68c7a6cf7c4c8326b5c543379c569f84