### PR TITLE
Ensure mail router import and path

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn app:app --host 0.0.0.0 --port ${PORT:-8080} --proxy-headers
+web: PYTHONPATH=. uvicorn app:app --host 0.0.0.0 --port ${PORT:-8080} --proxy-headers

--- a/server/routes/mail_manage.py
+++ b/server/routes/mail_manage.py
@@ -10,6 +10,7 @@ import imaplib
 from app import require_token, telegram_notify
 from server.utils.error_report import report_crit_error
 
+print("mail_router loaded")
 router = APIRouter(prefix="/mail")
 
 class DeleteRequest(BaseModel):


### PR DESCRIPTION
## Summary
- set PYTHONPATH in Procfile so `server.routes.mail_manage` can be imported
- add a startup log to `mail_manage` for easier troubleshooting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7b5946cb88326994ba7e35843604d