### PR TITLE
Fix indentation error in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -207,7 +207,6 @@ class DeleteRequest(BaseModel):
     id: int
 
 # ===== Send Functions =====
- getattr(resp, "status_code", None)
 
 def send_email(payload: SendMailPayload):
     if not sg:


### PR DESCRIPTION
## Summary
- remove the stray top-level getattr call near the send functions section to avoid indentation errors

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68ca37bf10308326a991618284692a14