### PR TITLE
Use add_attachment for SendGrid attachments

### DIFF
--- a/mailer_sg.py
+++ b/mailer_sg.py
@@ -87,7 +87,6 @@ async def send_email_sg(
 
     # 첨부 (content_b64 필수)
     if attachments_b64:
-        atts = []
         for att in attachments_b64:
             content_b64 = att.get("content_b64") or att.get("content")  # 호환 키
             if not content_b64:
@@ -95,7 +94,7 @@ async def send_email_sg(
             # 이미 b64라면 그대로, raw bytes가 온 경우 b64로 인코딩
             if isinstance(content_b64, (bytes, bytearray)):
                 content_b64 = base64.b64encode(content_b64).decode()
-            atts.append(
+            msg.add_attachment(
                 Attachment(
                     FileContent(content_b64),
                     FileName(att.get("filename", "attachment.bin")),
@@ -103,8 +102,6 @@ async def send_email_sg(
                     Disposition("attachment"),
                 )
             )
-        if atts:
-            msg.attachments = atts
 
     loop = asyncio.get_event_loop()
     return await loop.run_in_executor(None, _send_blocking, msg, retries, backoff)


### PR DESCRIPTION
## Summary
- replace manual attachments list assignment with direct add_attachment calls
- ensure attachments are appended without relying on SendGrid Mail.attachments property setters

## Testing
- python - <<'PY'
import os
os.environ['SENDGRID_API_KEY'] = 'dummy'

import asyncio
import mailer_sg

class DummyResponse:
    status_code = 202
    body = b''
    headers = {}

class DummyClient:
    def __init__(self, api_key):
        assert api_key == 'dummy'
    def send(self, msg):
        print('Attachments count:', len(getattr(msg, 'attachments', []) or []))
        return DummyResponse()

mailer_sg.SendGridAPIClient = DummyClient

async def main():
    result = await mailer_sg.send_email_sg(
        mail_from='sender@example.com',
        to=['recipient@example.com'],
        subject='Test',
        text='Body',
        attachments_b64=[{'content_b64': 'Y29udGVudA==', 'filename': 'test.txt', 'content_type': 'text/plain'}],
        retries=0
    )
    print('Send result:', result)

asyncio.run(main())
PY

------
https://chatgpt.com/codex/tasks/task_e_68ca3e59afec8326b4ed5cf5fddb1044