### PR TITLE
Use string addresses when building SendGrid payloads

### DIFF
--- a/app.py
+++ b/app.py
@@ -353,7 +353,7 @@ async def execute_action(action: dict, original_sender: str) -> dict:
                 to=to_list,
                 subject=action.get("subject", "카이아 자동 발송"),
                 text=action.get("content", ""),
-                from_=EmailStr("caia@caia-agent.com")
+                from_="caia@caia-agent.com"
             )
             
             result = send_email(payload)
@@ -375,10 +375,10 @@ async def execute_action(action: dict, original_sender: str) -> dict:
             content = action.get("content", "")
             # 동현에게 보고
             payload = SendMailPayload(
-                to=[EmailStr("flyartnam@gmail.com")],
+                to=["flyartnam@gmail.com"],
                 subject="[카이아 보고서] 자동 생성",
                 text=content,
-                from_=EmailStr("caia@caia-agent.com")
+                from_="caia@caia-agent.com"
             )
             send_email(payload)
             return {"success": True, "type": "report_created"}
@@ -739,10 +739,10 @@ async def inbound_sen_intelligent(
         reply_text = generate_intelligent_reply(analysis, text, subject, assistant_result)
         if reply_text:
             auto_reply_payload = SendMailPayload(
-                to=[EmailStr(from_field)],
+                to=[from_field],
                 subject=f"Re: {subject}",
                 text=reply_text,
-                from_=EmailStr("caia@caia-agent.com")
+                from_="caia@caia-agent.com"
             )
             try:
                 send_email(auto_reply_payload)
@@ -803,10 +803,10 @@ Type: {analysis['mail_type']}"""
 필요 조치: {', '.join(analysis['actions'])}"""
             
             forward_payload = SendMailPayload(
-                to=[EmailStr("flyartnam@gmail.com")],
+                to=["flyartnam@gmail.com"],
                 subject=f"[에이전트 보고] {subject}",
                 text=summary,
-                from_=EmailStr("caia@caia-agent.com")
+                from_="caia@caia-agent.com"
             )
             try:
                 send_email(forward_payload)
@@ -931,7 +931,7 @@ def test_send_email_get(
         to=[to],  # 리스트로 변환
         subject=subject,
         text=f"Test email sent via GET method at {dt.datetime.now()}",
-        from_=EmailStr("caia@caia-agent.com")
+        from_="caia@caia-agent.com"
     )
     
     try:


### PR DESCRIPTION
## Summary
- replace EmailStr constructor usages with raw string addresses when constructing SendMailPayload instances in app.py
- ensure auto-reply, owner forwarding, GPT action emails, and the test endpoint all build SendGrid payloads without wrapping addresses in EmailStr

## Testing
- pytest
- python - <<'PY'
from app import SendMailPayload

cases = {
    "execute_action_send": dict(
        to=["user@example.com"],
        subject="Test",
        text="Hello",
        from_="caia@caia-agent.com",
    ),
    "execute_action_report": dict(
        to=["flyartnam@gmail.com"],
        subject="[카이아 보고서] 자동 생성",
        text="Report contents",
        from_="caia@caia-agent.com",
    ),
    "auto_reply": dict(
        to=["sender@example.com"],
        subject="Re: Subject",
        text="Reply",
        from_="caia@caia-agent.com",
    ),
    "forward_owner": dict(
        to=["flyartnam@gmail.com"],
        subject="[에이전트 보고] Subject",
        text="Summary",
        from_="caia@caia-agent.com",
    ),
    "test_endpoint": dict(
        to=["recipient@example.com"],
        subject="Test Email",
        text="Body",
        from_="caia@caia-agent.com",
    ),
}

for name, params in cases.items():
    payload = SendMailPayload(**params)
    assert payload.from_ == "caia@caia-agent.com"
    assert all(isinstance(addr, str) for addr in params["to"])
    print(name, payload.to, payload.from_)
PY

------
https://chatgpt.com/codex/tasks/task_e_68cabfd3e1b88326bf4a8a584425835a